### PR TITLE
migrate replicator-4.0alpha2 to run under Python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.py[cod]
 *.swp
+,*
 
 # C extensions
 *.so

--- a/Cache.py
+++ b/Cache.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-import six
 import Params, os, hashlib
 
 

--- a/Cache.py
+++ b/Cache.py
@@ -8,7 +8,7 @@ def makedirs( path ):
   dir = os.path.dirname( path )
   if dir and not os.path.isdir( dir ):
     if os.path.isfile( dir ):
-      print 'directory %s mistaken for file' % dir
+      print('directory %s mistaken for file' % dir)
       os.remove( dir )
     else:
       makedirs( dir )
@@ -27,7 +27,7 @@ class File:
         item[:Params.MAXFILELEN-34] + '..' + hashlib.md5( item[Params.MAXFILELEN-34:] ).hexdigest()
           for item in path.split( os.sep ) )
       if newpath != path:
-        print 'Shortened path to %s characters' % '/'.join( str(len(w)) for w in newpath.split(os.sep) )
+        print('Shortened path to %s characters' % '/'.join( str(len(w)) for w in newpath.split(os.sep) ))
         path = newpath
 
     sep = path.find( '?' )
@@ -36,7 +36,7 @@ class File:
     if Params.FLAT:
       path = os.path.basename( path )
     if Params.VERBOSE:
-      print 'Cache position:', path
+      print('Cache position:', path)
 
     self.__path = Params.ROOT + path
     self.__file = None
@@ -51,12 +51,12 @@ class File:
 
   def open_new( self ):
 
-    print 'Preparing new file in cache'
+    print('Preparing new file in cache')
     try:
       makedirs( self.__path )
       self.__file = open( self.__path + Params.SUFFIX, 'w+' )
     except Exception, e:
-      print 'Failed to open file:', e
+      print('Failed to open file:', e)
       self.__file = os.tmpfile()
 
   def open_partial( self, offset=-1 ):
@@ -67,23 +67,23 @@ class File:
       assert offset <= self.tell(), 'range does not match file in cache'
       self.__file.seek( offset )
       self.__file.truncate()
-    print 'Resuming partial file in cache at byte', self.tell()
+    print('Resuming partial file in cache at byte', self.tell())
 
   def open_full( self ):
 
     self.mtime = os.stat( self.__path ).st_mtime
     self.__file = open( self.__path, 'r' )
     self.size = self.tell()
-    print 'Reading complete file from cache'
+    print('Reading complete file from cache')
 
   def remove_full( self ):
 
     os.remove( self.__path )
-    print 'Removed complete file from cache'
+    print('Removed complete file from cache')
 
   def remove_partial( self ):
 
-    print 'Removed partial file from cache'
+    print('Removed partial file from cache')
     os.remove( self.__path + Params.SUFFIX )
 
   def read( self, pos, size ):
@@ -109,7 +109,7 @@ class File:
       os.utime( self.__path + Params.SUFFIX, ( self.mtime, self.mtime ) )
     if self.size == size:
       os.rename( self.__path + Params.SUFFIX, self.__path )
-      print 'Finalized', self.__path
+      print('Finalized', self.__path)
 
   def __del__( self ):
 

--- a/Cache.py
+++ b/Cache.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
 import Params, os, hashlib
 
 

--- a/Cache.py
+++ b/Cache.py
@@ -44,7 +44,7 @@ class File:
       dir = os.path.dirname(self.__path)
       if not os.path.exists(dir):
           os.makedirs(dir)
-      self.__file = open( self.__path + Params.SUFFIX, 'w+' )
+      self.__file = open( self.__path + Params.SUFFIX, 'wb+' )
     except Exception as e:
       print('Failed to open file:', e)
       self.__file = os.tmpfile()
@@ -52,7 +52,7 @@ class File:
   def open_partial( self, offset=-1 ):
 
     self.mtime = os.stat( self.__path + Params.SUFFIX ).st_mtime
-    self.__file = open( self.__path + Params.SUFFIX, 'a+' )
+    self.__file = open( self.__path + Params.SUFFIX, 'ab+' )
     if offset >= 0:
       assert offset <= self.tell(), 'range does not match file in cache'
       self.__file.seek( offset )
@@ -62,7 +62,7 @@ class File:
   def open_full( self ):
 
     self.mtime = os.stat( self.__path ).st_mtime
-    self.__file = open( self.__path, 'r' )
+    self.__file = open( self.__path, 'rb' )
     self.size = self.tell()
     print('Reading complete file from cache')
 

--- a/Cache.py
+++ b/Cache.py
@@ -3,18 +3,6 @@ import six
 import Params, os, hashlib
 
 
-def makedirs( path ):
-
-  dir = os.path.dirname( path )
-  if dir and not os.path.isdir( dir ):
-    if os.path.isfile( dir ):
-      print('directory %s mistaken for file' % dir)
-      os.remove( dir )
-    else:
-      makedirs( dir )
-    os.mkdir( dir )
-
-
 class File:
 
   size = -1
@@ -53,7 +41,7 @@ class File:
 
     print('Preparing new file in cache')
     try:
-      makedirs( self.__path )
+      os.makedirs( self.__path )
       self.__file = open( self.__path + Params.SUFFIX, 'w+' )
     except Exception as e:
       print('Failed to open file:', e)

--- a/Cache.py
+++ b/Cache.py
@@ -41,7 +41,9 @@ class File:
 
     print('Preparing new file in cache')
     try:
-      os.makedirs(os.path.dirname(self.__path))
+      dir = os.path.dirname(self.__path)
+      if not os.path.exists(dir):
+          os.makedirs(dir)
       self.__file = open( self.__path + Params.SUFFIX, 'w+' )
     except Exception as e:
       print('Failed to open file:', e)

--- a/Cache.py
+++ b/Cache.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
+import six
 import Params, os, hashlib
 
 

--- a/Cache.py
+++ b/Cache.py
@@ -55,7 +55,7 @@ class File:
     try:
       makedirs( self.__path )
       self.__file = open( self.__path + Params.SUFFIX, 'w+' )
-    except Exception, e:
+    except Exception as e:
       print('Failed to open file:', e)
       self.__file = os.tmpfile()
 

--- a/Cache.py
+++ b/Cache.py
@@ -41,7 +41,7 @@ class File:
 
     print('Preparing new file in cache')
     try:
-      os.makedirs( self.__path )
+      os.makedirs(os.path.dirname(self.__path))
       self.__file = open( self.__path + Params.SUFFIX, 'w+' )
     except Exception as e:
       print('Failed to open file:', e)

--- a/Params.py
+++ b/Params.py
@@ -82,4 +82,4 @@ for _arg in _args:
   else:
     sys.exit( 'Error: invalid option %r' % _arg )
 
-MAXFILELEN = os.pathconf( ROOT, 'PC_NAME_MAX' ) - len(SUFFIX)
+MAXFILELEN = os.pathconf( ROOT, b'PC_NAME_MAX' ) - len(SUFFIX)

--- a/Params.py
+++ b/Params.py
@@ -4,7 +4,7 @@ import sys, os, socket
 
 _args = iter( sys.argv )
 
-PROG = _args.next()
+PROG = next(_args)
 PORT = 8080
 ROOT = os.getcwd() + os.sep
 VERBOSE = 0
@@ -41,13 +41,13 @@ for _arg in _args:
     sys.exit( USAGE )
   elif _arg in ( '-p', '--port' ):
     try:
-      PORT = int( _args.next() )
+      PORT = int( next(_args) )
       assert PORT > 0
     except:
       sys.exit( 'Error: %s requires a positive numerical argument' % _arg )
   elif _arg in ( '-r', '--root' ):
     try:
-      ROOT = os.path.realpath( _args.next() ) + os.sep
+      ROOT = os.path.realpath( next(_args) ) + os.sep
       assert os.path.isdir( ROOT )
     except StopIteration:
       sys.exit( 'Error: %s requires a directory argument' % _arg )
@@ -57,7 +57,7 @@ for _arg in _args:
     VERBOSE += 1
   elif _arg in ( '-t', '--timeout' ):
     try:
-      TIMEOUT = int( _args.next() )
+      TIMEOUT = int( next(_args) )
       assert TIMEOUT > 0
     except:
       sys.exit( 'Error: %s requires a positive numerical argument' % _arg )
@@ -72,11 +72,11 @@ for _arg in _args:
     STATIC = True
   elif _arg == '--limit':
     try:
-      LIMIT = float( _args.next() ) * 1024
+      LIMIT = float( next(_args) ) * 1024
     except:
       sys.exit( 'Error: %s requires a numerical argument' % _arg )
   elif _arg == '--daemon':
-    LOG = _args.next()
+    LOG = next(_args)
   elif _arg == '--debug':
     DEBUG = True
   else:

--- a/Params.py
+++ b/Params.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
 import sys, os, socket
 
 _args = iter( sys.argv )

--- a/Params.py
+++ b/Params.py
@@ -17,6 +17,8 @@ parser = argparse.ArgumentParser(description = 'http-replicator: a caching http 
 
 parser.add_argument('-p', '--port', type=port_number, default=8080,
         help='listen on PORT for incoming connections (default=8080)')
+parser.add_argument('-b', '--bind', default='::1', metavar='ADDRESS',
+        help='bind server to ADDRESS (default=::1)')
 parser.add_argument('-r', '--root', default=os.getcwd(),
         help='set cache base directory to ROOT, default is the current directory')
 parser.add_argument('-v', '--verbose', action='count',
@@ -42,6 +44,7 @@ args = parser.parse_args()
 
 # allow old names (for now)
 PORT = args.port
+BIND = args.bind
 ROOT = os.path.realpath(args.root) + os.sep
 VERBOSE = args.verbose
 TIMEOUT = args.timeout

--- a/Params.py
+++ b/Params.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
+import six
 import sys, os, socket
 
 _args = iter( sys.argv )

--- a/Params.py
+++ b/Params.py
@@ -50,6 +50,7 @@ STATIC = args.static
 ONLINE = not args.offline
 LIMIT = args.limit * 1024
 LOG = args.daemon
+PIDFILE = args.pid
 DEBUG = args.debug
 
 if not os.path.isdir(ROOT):

--- a/Params.py
+++ b/Params.py
@@ -21,7 +21,7 @@ parser.add_argument('-b', '--bind', default='::1', metavar='ADDRESS',
         help='bind server to ADDRESS (default=::1)')
 parser.add_argument('-r', '--root', default=os.getcwd(),
         help='set cache base directory to ROOT, default is the current directory')
-parser.add_argument('-v', '--verbose', action='count',
+parser.add_argument('-v', '--verbose', default=0, action='count',
         help='show http headers and other info')
 parser.add_argument('-t', '--timeout', type=positive_number, default=15,
         help='break connection after TIMEOUT seconds of inactivity (default=15)')

--- a/Protocol.py
+++ b/Protocol.py
@@ -10,12 +10,12 @@ def connect( addr ):
   assert Params.ONLINE, 'operating in off-line mode'
   if addr not in DNSCache:
     if Params.VERBOSE:
-      print 'Requesting address info for %s:%i' % addr
+      print('Requesting address info for %s:%i' % addr)
     DNSCache[ addr ] = socket.getaddrinfo( addr[ 0 ], addr[ 1 ], Params.FAMILY, socket.SOCK_STREAM )
 
   family, socktype, proto, canonname, sockaddr = DNSCache[ addr ][ 0 ]
 
-  print 'Connecting to %s:%i' % sockaddr
+  print('Connecting to %s:%i' % sockaddr)
   sock = socket.socket( family, socktype, proto )
   sock.setblocking( 0 )
   sock.connect_ex( sockaddr )
@@ -65,7 +65,7 @@ class HttpProtocol( Cache.File ):
     Cache.File.__init__( self, request.cache )
 
     if Params.STATIC and self.full():
-      print 'Static mode; serving file directly from cache'
+      print('Static mode; serving file directly from cache')
       self.__socket = None
       self.open_full()
       self.Response = Response.DataResponse
@@ -80,11 +80,11 @@ class HttpProtocol( Cache.File ):
       size = stat.st_size
       mtime = time.strftime( Params.TIMEFMT[0], time.gmtime( stat.st_mtime ) )
       if self.partial():
-        print 'Requesting resume of partial file in cache: %i bytes, %s' % ( size, mtime )
+        print('Requesting resume of partial file in cache: %i bytes, %s' % ( size, mtime ))
         args[ 'Range' ] = 'bytes=%i-' % size
         args[ 'If-Range' ] = mtime
       else:
-        print 'Checking complete file in cache: %i bytes, %s' % ( size, mtime )
+        print('Checking complete file in cache: %i bytes, %s' % ( size, mtime ))
         args[ 'If-Modified-Since' ] = mtime
 
     self.__socket = connect( request.addr )
@@ -110,7 +110,7 @@ class HttpProtocol( Cache.File ):
       return 0
 
     line = chunk[ :eol ]
-    print 'Server responds', line.rstrip()
+    print('Server responds', line.rstrip())
     fields = line.split()
     assert len( fields ) >= 3 and fields[ 0 ].startswith( 'HTTP/' ) and fields[ 1 ].isdigit(), 'invalid header line: %r' % line
     self.__status = int( fields[ 1 ] )
@@ -129,7 +129,7 @@ class HttpProtocol( Cache.File ):
     line = chunk[ :eol ]
     if ':' in line:
       if Params.VERBOSE > 1:
-        print '>', line.rstrip()
+        print('>', line.rstrip())
       key, value = line.split( ':', 1 )
       key = key.title()
       if key in self.__args:
@@ -139,7 +139,7 @@ class HttpProtocol( Cache.File ):
     elif line in ( '\r\n', '\n' ):
       self.__parse = None
     else:
-      print 'Ignored header line:', line
+      print('Ignored header line:', line)
 
     return eol
 
@@ -266,11 +266,11 @@ class FtpProtocol( Cache.File ):
     while '\n' in self.__recvbuf:
       reply, self.__recvbuf = self.__recvbuf.split( '\n', 1 )
       if Params.VERBOSE > 1:
-        print 'S:', reply.rstrip()
+        print('S:', reply.rstrip())
       if reply[ :3 ].isdigit() and reply[ 3 ] != '-':
         self.__handle( self, int( reply[ :3 ] ), reply[ 4: ] )
         if self.__sendbuf and Params.VERBOSE > 1:
-          print 'C:', self.__sendbuf.rstrip()
+          print('C:', self.__sendbuf.rstrip())
 
   def __handle_serviceready( self, code, line ):
 
@@ -313,7 +313,7 @@ class FtpProtocol( Cache.File ):
 
     assert code == 213, 'server sends %i; expected 213 (file status)' % code
     self.size = int( line )
-    print 'File size:', self.size
+    print('File size:', self.size)
     self.__sendbuf = 'MDTM %s\r\n' % self.__path
     self.__handle = FtpProtocol.__handle_mtime
 
@@ -325,7 +325,7 @@ class FtpProtocol( Cache.File ):
 
     assert code == 213, 'server sends %i; expected 213 (file status)' % code
     self.mtime = calendar.timegm( time.strptime( line.rstrip(), '%Y%m%d%H%M%S' ) )
-    print 'Modification time:', time.strftime( Params.TIMEFMT[0], time.gmtime( self.mtime ) )
+    print('Modification time:', time.strftime( Params.TIMEFMT[0], time.gmtime( self.mtime ) ))
     stat = self.partial()
     if stat and stat.st_mtime == self.mtime:
       self.__sendbuf = 'REST %i\r\n' % stat.st_size

--- a/Protocol.py
+++ b/Protocol.py
@@ -291,7 +291,6 @@ class FtpProtocol( Cache.File ):
   def __handle_binarymode( self, code, line ):
 
     assert code == 200, 'server sends %i; expected 200 (binary mode ok)' % code
-    print(self.__socket)
     if self.__socket.family == socket.AF_INET6:
         self.__sendbuf = b'EPSV\r\n'
         self.__handle = FtpProtocol.__handle_Epassivemode

--- a/Protocol.py
+++ b/Protocol.py
@@ -15,7 +15,7 @@ def connect( addr ):
 
   family, socktype, proto, canonname, sockaddr = DNSCache[ addr ][ 0 ]
 
-  print('Connecting to %s:%i' % sockaddr)
+  print('Connecting to %s:%i' % sockaddr[:2])
   sock = socket.socket( family, socktype, proto )
   sock.setblocking( 0 )
   sock.connect_ex( sockaddr )

--- a/Protocol.py
+++ b/Protocol.py
@@ -11,7 +11,7 @@ def connect( addr ):
   if addr not in DNSCache:
     if Params.VERBOSE:
       print('Requesting address info for %s:%i' % addr)
-    DNSCache[ addr ] = socket.getaddrinfo( addr[ 0 ], addr[ 1 ], Params.FAMILY, socket.SOCK_STREAM )
+    DNSCache[ addr ] = socket.getaddrinfo( addr[ 0 ], addr[ 1 ], socket.AF_UNSPEC, socket.SOCK_STREAM )
 
   family, socktype, proto, canonname, sockaddr = DNSCache[ addr ][ 0 ]
 

--- a/Protocol.py
+++ b/Protocol.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
 import Params, Response, Cache, time, socket, os, sys, calendar
 
 

--- a/Protocol.py
+++ b/Protocol.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
+import six
 import Params, Response, Cache, time, socket, os, sys, calendar
 
 

--- a/Protocol.py
+++ b/Protocol.py
@@ -88,7 +88,7 @@ class HttpProtocol( Cache.File ):
         args[ 'If-Modified-Since' ] = mtime
 
     self.__socket = connect( request.addr )
-    self.__sendbuf = '\r\n'.join( [ head ] + map( ': '.join, args.items() ) + [ '', '' ] )
+    self.__sendbuf = '\r\n'.join( [ head ] + list(map( ': '.join, iter(args.items()) )) + [ '', '' ] )
     self.__recvbuf = ''
     self.__parse = HttpProtocol.__parse_head
 
@@ -210,7 +210,7 @@ class HttpProtocol( Cache.File ):
 
   def recvbuf( self ):
 
-    return '\r\n'.join( [ 'HTTP/1.1 %i %s' % ( self.__status, self.__message ) ] + map( ': '.join, self.__args.items() ) + [ '', '' ] )
+    return '\r\n'.join( [ 'HTTP/1.1 %i %s' % ( self.__status, self.__message ) ] + list(map( ': '.join, iter(self.__args.items()) )) + [ '', '' ] )
 
   def args( self ):
 

--- a/Protocol.py
+++ b/Protocol.py
@@ -80,7 +80,6 @@ class HttpProtocol( Cache.File ):
       if self.partial():
         print('Requesting resume of partial file in cache: %i bytes, %s' % ( size, mtime ))
         args[ b'Range' ] = b'bytes=%i-' % size
-        args[ b'If-Range' ] = mtime.encode()
       else:
         print('Checking complete file in cache: %i bytes, %s' % ( size, mtime ))
         args[ b'If-Modified-Since' ] = mtime.encode()
@@ -342,7 +341,7 @@ class FtpProtocol( Cache.File ):
     self.mtime = calendar.timegm( time.strptime( line.decode().rstrip(), '%Y%m%d%H%M%S' ) )
     print('Modification time:', time.strftime( Params.TIMEFMT[0], time.gmtime( self.mtime ) ))
     stat = self.partial()
-    if stat and stat.st_mtime == self.mtime:
+    if stat:
       self.__sendbuf = b'REST %i\r\n' % stat.st_size
       self.__handle = FtpProtocol.__handle_resume
     else:

--- a/Protocol.py
+++ b/Protocol.py
@@ -298,7 +298,8 @@ class FtpProtocol( Cache.File ):
 
     assert code == 227, 'server sends %i; expected 227 (passive mode)' % code
     channel = line.split()[-1].rstrip(b'.')
-    channel = eval(channel) #should look like a tuple
+    channel = eval(channel)
+    assert len(channel) == 6, 'offered FTP PASV channel is unsupported (can only handle IPv4)'
     addr = b'%i.%i.%i.%i' % channel[:4], channel[4]*256 + channel[5]
     self.__socket = connect( addr )
     self.__sendbuf = b'SIZE %s\r\n' % self.__path

--- a/Protocol.py
+++ b/Protocol.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-import six
 import Params, Response, Cache, time, socket, os, sys, calendar
 
 

--- a/Protocol.py
+++ b/Protocol.py
@@ -299,7 +299,8 @@ class FtpProtocol( Cache.File ):
   def __handle_passivemode( self, code, line ):
 
     assert code == 227, 'server sends %i; expected 227 (passive mode)' % code
-    channel = eval( line.split()[ -1 ] )
+    channel = line.split()[-1].rstrip('.')
+    channel = eval(channel) #should look like a tuple
     addr = '%i.%i.%i.%i' % channel[ :4 ], channel[ 4 ] * 256 + channel[ 5 ]
     self.__socket = connect( addr )
     self.__sendbuf = 'SIZE %s\r\n' % self.__path

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ arguments can be used to change this default behaviour:
 
     -h --help
      Show this help message and exit.
+
+    -b --bind ADDRESS
+     bind server to ADDRESS, default=::1
    
     -p --port PORT
      Listen on this port for incoming connections, default 8080.
@@ -39,9 +42,6 @@ arguments can be used to change this default behaviour:
    
     -t --timeout SEC
      Break connection after so many seconds of inactivity, default 15
-   
-    -6 --ipv6
-     Try ipv6 addresses if available
    
     --flat
      Flat mode; cache all files in root directory (dangerous!)
@@ -57,6 +57,10 @@ arguments can be used to change this default behaviour:
    
     --daemon LOG
      Route output to log and detach
+
+    --pid PIDFILE
+     if --daemon is used, write pid of daemon to PIDFILE
    
     --debug
      Switch from gather to debug output module
+

--- a/Request.py
+++ b/Request.py
@@ -133,7 +133,7 @@ class HttpRequest:
   def recvbuf( self ):
 
     lines = [ '%s /%s HTTP/1.1' % ( self.cmd, self.path ) ]
-    lines.extend( map( ': '.join, self.args.items() ) )
+    lines.extend( list(map( ': '.join, self.args.items() )) )
     lines.append( '' )
     if self.size:
       self.body.seek( 0 )

--- a/Request.py
+++ b/Request.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-import six
 import Params, Protocol, socket, os, fiber
 
 

--- a/Request.py
+++ b/Request.py
@@ -81,7 +81,7 @@ class HttpRequest:
       host = url[ 6: ]
       port = 21
     else:
-      raise AssertionError, 'invalid url: %s' % url
+      raise AssertionError('invalid url: %s' % url)
 
     if '/' in host:
       host, path = host.split( '/', 1 )
@@ -116,7 +116,7 @@ class HttpRequest:
         else:
           range = int( beg ), int( end ) + 1
       except:
-        raise AssertionError, 'invalid range specification: %s' % range
+        raise AssertionError('invalid range specification: %s' % range)
     else:
       range = 0, -1
 

--- a/Request.py
+++ b/Request.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
 import Params, Protocol, socket, os, fiber
 
 

--- a/Request.py
+++ b/Request.py
@@ -26,7 +26,7 @@ class HttpRequest:
       yield fiber.RECV( self.client, Params.TIMEOUT )
       recvbuf += self.recv()
     header, recvbuf = recvbuf.split( '\n', 1 )
-    print 'Client sends', header.rstrip()
+    print('Client sends', header.rstrip())
 
     self.__parse_header( header )
 
@@ -38,13 +38,13 @@ class HttpRequest:
       line, recvbuf = recvbuf.split( '\n', 1 )
       if ':' in line:
         if Params.VERBOSE > 1:
-          print '>', line.rstrip()
+          print('>', line.rstrip())
         key, value = line.split( ':', 1 )
         key = key.title()
         assert key not in args, 'duplicate key: %s' % key
         args[ key ] = value.strip()
       elif line and line != '\r':
-        print 'Ignored header line: %r' % line.rstrip()
+        print('Ignored header line: %r' % line.rstrip())
       else:
         break
 
@@ -52,7 +52,7 @@ class HttpRequest:
 
     if self.size:
       if Params.VERBOSE:
-        print 'Opening temporary file for POST upload'
+        print('Opening temporary file for POST upload')
       self.body = os.tmpfile()
       self.body.write( recvbuf )
       while self.body.tell() < self.size:

--- a/Request.py
+++ b/Request.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
+import six
 import Params, Protocol, socket, os, fiber
 
 

--- a/Response.py
+++ b/Response.py
@@ -70,10 +70,10 @@ class DataResponse:
       args[ 'Content-Range' ] = 'bytes */*'
       args[ 'Content-Length' ] = '0'
 
-    print 'Replicator responds', head
+    print('Replicator responds', head)
     if Params.VERBOSE > 1:
       for key in args:
-        print '> %s: %s' % ( key, args[ key ].replace( '\r\n', ' > ' ) )
+        print('> %s: %s' % ( key, args[ key ].replace( '\r\n', ' > ' ) ))
 
     self.__sendbuf = '\r\n'.join( [ head ] + map( ': '.join, args.items() ) + [ '', '' ] )
     if Params.LIMIT:
@@ -121,7 +121,7 @@ class DataResponse:
         assert self.__protocol.size == self.__protocol.tell(), 'connection closed prematurely'
       else:
         self.__protocol.size = self.__protocol.tell()
-        print 'Connection closed at byte', self.__protocol.size
+        print('Connection closed at byte', self.__protocol.size)
       self.Done = not self.hasdata()
 
 
@@ -144,14 +144,14 @@ class ChunkedDataResponse( DataResponse ):
       chunksize = int( head.split( ';' )[ 0 ], 16 )
       if chunksize == 0:
         self.__protocol.size = self.__protocol.tell()
-        print 'Connection closed at byte', self.__protocol.size
+        print('Connection closed at byte', self.__protocol.size)
         self.Done = not self.hasdata()
         return
       if len( tail ) < chunksize + 2:
         return
       assert tail[ chunksize:chunksize+2 ] == '\r\n', 'chunked data error: chunk does not match announced size'
       if Params.VERBOSE > 1:
-        print 'Received', chunksize, 'byte chunk'
+        print('Received', chunksize, 'byte chunk')
       self.__protocol.write( tail[ :chunksize ] )
       self.__recvbuf = tail[ chunksize+2: ]
 

--- a/Response.py
+++ b/Response.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
+import six
 import Params, time, traceback
 
 

--- a/Response.py
+++ b/Response.py
@@ -75,7 +75,7 @@ class DataResponse:
       for key in args:
         print('> %s: %s' % ( key, args[ key ].replace( '\r\n', ' > ' ) ))
 
-    self.__sendbuf = '\r\n'.join( [ head ] + map( ': '.join, args.items() ) + [ '', '' ] )
+    self.__sendbuf = '\r\n'.join( [ head ] + list(map( ': '.join, iter(args.items()) )) + [ '', '' ] )
     if Params.LIMIT:
       self.__nextrecv = 0
 

--- a/Response.py
+++ b/Response.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
 import Params, time, traceback
 
 

--- a/Response.py
+++ b/Response.py
@@ -50,32 +50,32 @@ class DataResponse:
       args = self.__protocol.args()
     except:
       args = {}
-    args[ 'Connection' ] = 'close'
-    args[ 'Date' ] = time.strftime( Params.TIMEFMT[0], time.gmtime() )
+    args[ b'Connection' ] = b'close'
+    args[ b'Date' ] = time.strftime( Params.TIMEFMT[0], time.gmtime() ).encode()
     if self.__protocol.mtime >= 0:
-      args[ 'Last-Modified' ] = time.strftime( Params.TIMEFMT[0], time.gmtime( self.__protocol.mtime ) )
+      args[ b'Last-Modified' ] = time.strftime( Params.TIMEFMT[0], time.gmtime( self.__protocol.mtime ) ).encode()
     if self.__pos == 0 and self.__end == self.__protocol.size:
-      head = 'HTTP/1.1 200 OK'
+      head = b'HTTP/1.1 200 OK'
       if self.__protocol.size >= 0:
-        args[ 'Content-Length' ] = str( self.__protocol.size )
+        args[ b'Content-Length' ] = b'%i' % (self.__protocol.size)
     elif self.__end >= 0:
-      head = 'HTTP/1.1 206 Partial Content'
-      args[ 'Content-Length' ] = str( self.__end - self.__pos )
+      head = b'HTTP/1.1 206 Partial Content'
+      args[ b'Content-Length' ] = b'%i' % (self.__end - self.__pos)
       if self.__protocol.size >= 0:
-        args[ 'Content-Range' ] = 'bytes %i-%i/%i' % ( self.__pos, self.__end - 1, self.__protocol.size )
+        args[ b'Content-Range' ] = b'bytes %i-%i/%i' % ( self.__pos, self.__end - 1, self.__protocol.size )
       else:
-        args[ 'Content-Range' ] = 'bytes %i-%i/*' % ( self.__pos, self.__end - 1 )
+        args[ b'Content-Range' ] = b'bytes %i-%i/*' % ( self.__pos, self.__end - 1 )
     else:
-      head = 'HTTP/1.1 416 Requested Range Not Satisfiable'
-      args[ 'Content-Range' ] = 'bytes */*'
-      args[ 'Content-Length' ] = '0'
+      head = b'HTTP/1.1 416 Requested Range Not Satisfiable'
+      args[ b'Content-Range' ] = b'bytes */*'
+      args[ b'Content-Length' ] = b'0'
 
-    print('Replicator responds', head)
+    print('Replicator responds', head.decode())
     if Params.VERBOSE > 1:
       for key in args:
-        print('> %s: %s' % ( key, args[ key ].replace( '\r\n', ' > ' ) ))
+        print('> %s: %s' % ( key.decode(), args[ key ].replace(b'\r\n', b' > ').decode() ))
 
-    self.__sendbuf = '\r\n'.join( [ head ] + list(map( ': '.join, iter(args.items()) )) + [ '', '' ] )
+    self.__sendbuf = b'\r\n'.join( [ head ] + list(map( b': '.join, iter(args.items()) )) + [ b'', b'' ] )
     if Params.LIMIT:
       self.__nextrecv = 0
 
@@ -131,7 +131,7 @@ class ChunkedDataResponse( DataResponse ):
 
     DataResponse.__init__( self, protocol, request )
     self.__protocol = protocol
-    self.__recvbuf = ''
+    self.__recvbuf = b''
 
   def recv( self, sock ):
 
@@ -139,9 +139,9 @@ class ChunkedDataResponse( DataResponse ):
     chunk = sock.recv( Params.MAXCHUNK )
     assert chunk, 'chunked data error: connection closed prematurely'
     self.__recvbuf += chunk
-    while '\r\n' in self.__recvbuf:
-      head, tail = self.__recvbuf.split( '\r\n', 1 )
-      chunksize = int( head.split( ';' )[ 0 ], 16 )
+    while b'\r\n' in self.__recvbuf:
+      head, tail = self.__recvbuf.split( b'\r\n', 1 )
+      chunksize = int( head.split( b';' )[ 0 ], 16 )
       if chunksize == 0:
         self.__protocol.size = self.__protocol.tell()
         print('Connection closed at byte', self.__protocol.size)
@@ -149,7 +149,7 @@ class ChunkedDataResponse( DataResponse ):
         return
       if len( tail ) < chunksize + 2:
         return
-      assert tail[ chunksize:chunksize+2 ] == '\r\n', 'chunked data error: chunk does not match announced size'
+      assert tail[ chunksize:chunksize+2 ] == b'\r\n', 'chunked data error: chunk does not match announced size'
       if Params.VERBOSE > 1:
         print('Received', chunksize, 'byte chunk')
       self.__protocol.write( tail[ :chunksize ] )
@@ -162,16 +162,16 @@ class DirectResponse:
 
   def __init__( self, status, request ):
 
-    lines = [ 'HTTP Replicator: %s' % status, '', 'Requesting:' ]
-    head, body = request.recvbuf().split( '\r\n\r\n', 1 )
+    lines = [ b'HTTP Replicator: %s' % status, b'', b'Requesting:' ]
+    head, body = request.recvbuf().split( b'\r\n\r\n', 1 )
     for line in head.splitlines():
-      lines.append( len( line ) > 78 and '  %s...' % line[ :75 ] or '  %s' % line )
+      lines.append( len( line ) > 78 and b'  %s...' % line[ :75 ] or b'  %s' % line )
     if body:
-      lines.append( '+ Body: %i bytes' % len( body ) )
-    lines.append( '' )
-    lines.append( traceback.format_exc() )
+      lines.append( b'+ Body: %i bytes' % len( body ) )
+    lines.append( b'' )
+    lines.append( traceback.format_exc().encode() )
 
-    self.__sendbuf = 'HTTP/1.1 %s\r\nContent-Type: text/plain\r\n\r\n%s' % ( status, '\n'.join( lines ) )
+    self.__sendbuf = b'HTTP/1.1 %s\r\nContent-Type: text/plain\r\n\r\n%s' % ( status, b'\n'.join( lines ) )
     
   def hasdata( self ):
 
@@ -198,7 +198,7 @@ class NotFoundResponse( DirectResponse ):
 
   def __init__( self, protocol, request ):
 
-    DirectResponse.__init__( self, '404 Not Found', request )
+    DirectResponse.__init__( self, b'404 Not Found', request )
 
 
 class ExceptionResponse( DirectResponse ):
@@ -206,4 +206,4 @@ class ExceptionResponse( DirectResponse ):
   def __init__( self, request ):
 
     traceback.print_exc()
-    DirectResponse.__init__( self, '500 Internal Server Error', request )
+    DirectResponse.__init__( self, b'500 Internal Server Error', request )

--- a/Response.py
+++ b/Response.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-import six
 import Params, time, traceback
 
 

--- a/extras/http-replicator.service
+++ b/extras/http-replicator.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=http-replicator daemon
+After=network.target 
+
+[Service]
+ExecStart=/usr/bin/http-replicator -s -f \
+		--dir /var/cache/http-replicator --user portage --log /var/log/http-replicator.log \
+		$DAEMON_OPTS
+
+[Install]
+WantedBy=multi-user.target

--- a/extras/repcacheman.py
+++ b/extras/repcacheman.py
@@ -1,0 +1,201 @@
+#! /usr/bin/python2.7
+#
+# repcacheman ver 0.44
+#
+# Cache Manager for Http-Replicator
+# deletes duplicate files in PORTDIR.
+# imports authenticated (checksum + listed in portage)
+# files from PORTDIR to replicator's cache directory.
+#
+# Uses portage to perform checksum and database functions.
+# All else, Copyright(C)2004-2007 Tom Poplawski (poplawtm@earthlink.net)
+# Distributed under the terms of the GNU General Public License v2
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+
+import portage.manifest
+import portage.checksum
+import portage.exception
+import portage
+import string
+import os
+import pwd,sys,optparse
+
+if os.getuid():
+	print"Must be root"
+	sys.exit(1)
+
+# Parse Options
+
+parser = optparse.OptionParser()
+parser.add_option('-d', '--dir', type='string', default="/var/cache/http-replicator", help='http-replicators cache DIR')
+parser.add_option('-u','--user', type='string', default="portage", help='http-replicator USER')
+options, args = parser.parse_args() # parse command line
+
+if options.user:
+	try:
+		uid=pwd.getpwnam(options.user)[2]
+		gid=pwd.getpwnam(options.user)[3]
+	except:
+		print "User \'" + options.user + "\' Doesn't exist on system - edit config or add user to system."
+		sys.exit(1)
+else:
+	print "Error\n\tunable to get USER from /etc/http-replicator.conf"
+	sys.exit(1)
+
+# dir is replicator's cache directory
+dir=options.dir+"/"
+
+if os.path.isdir(dir) :
+	newdir=0
+else :
+	print"\n\nBegin Http-Replicator Setup...."
+	try:
+		os.makedirs(dir)
+		print "\tcreated " + dir
+		newdir=1
+	except:
+		print "\tcreate " + dir + " failed"
+		print '\terror:', sys.exc_info()[1]
+		sys.exit(1)
+	try:
+		os.chown(dir,uid,gid)
+		print "\tchanged owner of " + dir + " to " + options.user 
+	except:
+		print "\tchange owner " + dir + " to " + options.user + " failed:"
+		print '\terror:', sys.exc_info()[1]
+
+print "\n\nReplicator's cache directory: " + dir
+
+# Import Portage settings
+
+distdir=portage.settings["DISTDIR"]+"/"
+if distdir:
+	print "Portage's DISTDIR: " + distdir
+else:
+	print"Unable to get Portage's DISTDIR"
+	sys.exit(1)
+
+# Start Work
+
+print "\nComparing directories...."
+
+# Create filecmp object
+import filecmp
+dc=filecmp.dircmp (distdir,dir,['cvs-src','git-src','hg-src','egit-src','.locks'])
+print "Done!"
+
+dupes=dc.common
+deleted=0
+
+if dupes:
+	print "\nDeleting duplicate file(s) in " + distdir
+
+	for s in dupes:
+		print s
+		try:
+			os.remove(distdir + s )
+			deleted +=1
+		except:
+			print "\tdelete " + distdir + s + " failed:"
+			print '\terror:', sys.exc_info()[1]
+
+	print "Done!"
+
+
+newfiles=dc.left_only
+nf=len(dc.left_only)
+
+if nf:
+	print "\nNew files in DISTDIR:"
+	for s in newfiles:
+		print s
+	print"\nChecking authenticity and integrity of new files..."
+	added=0
+	errors=0
+	badsum=0
+
+# search all packages 
+
+	for mycp in portage.db["/"]["porttree"].dbapi.cp_all():
+		manifest = portage.manifest.Manifest("/usr/portage/" + mycp , distdir)
+		if manifest == None:
+			portage.writemsg("Missing manifest: %s\n" % mycpv)
+
+		remove=[]
+		for file in newfiles:
+			if manifest.hasFile("DIST",file):
+				try:
+					myok, myreason = manifest.checkFileHashes("DIST",file)
+					
+					try:
+						os.rename(distdir+file,dir+file)
+						added += 1
+					except:
+						try:
+							import shutil
+							shutil.copyfile(distdir+file,dir+file)
+							added += 1
+							os.remove(distdir+file)
+						except:
+							print "\tmove/copy " + file + " failed:"
+							print '\terror:', sys.exc_info()[1]
+							errors+=1
+							
+					try:
+						os.chown(dir+file,uid,gid)
+					except:
+						print "\tchown " + file + " failed:"
+						print '\terror:', sys.exc_info()[1]
+						errors +=1
+						
+					remove.append( file )
+					
+				except portage.exception.DigestException, e:
+					print("\n!!! Digest verification failed:")
+					print("!!! %s" % e.value[0])
+					print("!!! Reason: %s" % e.value[1])
+					print("!!! Got: %s" % e.value[2])
+					print("!!! Expected: %s" % e.value[3])
+					badsum+=1
+		if remove:
+			for rf in remove:
+				newfiles.remove ( rf )
+
+
+print "\nSUMMARY:"
+print "Found " + str(len(dupes)) + " duplicate file(s)"
+if deleted:
+	print "\tDeleted " + str(deleted) + " dupe(s)"
+
+if nf:
+	print "Found " + str(nf) + " new file(s)"
+	print "\tAdded " + str(added) + " of those file(s) to the cache"
+	
+	print "Rejected " +str(len(newfiles))  + " File(s) - ",
+	print str(badsum) +  " failed checksum(s)"
+	for s in newfiles:
+		print "\t%s" %s
+	if errors:
+		print "Encountered " +str(errors) + " errors"
+#	if badsum:
+#		print str(badsum) + " partial/corrupted file(s)"
+
+if newdir:
+	print"\n\nexecute:\n/etc/init.d/http-replicator start"
+	print"to run http-replicator.\n\nexecute:\nrc-update add http-replicator default"
+	print"to make http-replicator start at boot"
+	print"\n\nexecute:\n/usr/bin/repcacheman\nafter emerge's on the server to delete"
+	print"dup files and add new files to the cache"
+
+print "\n\nHTTP-Replicator requires you delete any partial downloads in " + distdir
+print "run rm -f " + distdir +'*'
+

--- a/fiber.py
+++ b/fiber.py
@@ -137,12 +137,14 @@ class DebugFiber( Fiber ):
     self.__newline = string.endswith( '\n' )
 
 
-def fork( output ):
+def fork( output, pidfile ):
 
   try:
     log = open( output, 'w' )
     nul = open( '/dev/null', 'r' )
     pid = os.fork()
+    if pidfile:
+      pidout = open(pidfile, 'w') # open pid file for writing
   except IOError as e:
     print('error: failed to open', e.filename)
     sys.exit( 1 )
@@ -169,6 +171,9 @@ def fork( output ):
 
   if pid:
     print(pid)
+    if pidfile:
+      pidout.write(str(pid))
+      pidout.close()
     sys.exit( 0 )
 
   os.dup2( log.fileno(), sys.stdout.fileno() )
@@ -176,7 +181,7 @@ def fork( output ):
   os.dup2( nul.fileno(), sys.stdin.fileno()  )
 
 
-def spawn( generator, port, debug, log ):
+def spawn( generator, port, debug=False, log=None, pidfile=None ):
 
   try:
     listener = socket.socket( socket.AF_INET, socket.SOCK_STREAM )
@@ -189,7 +194,7 @@ def spawn( generator, port, debug, log ):
     sys.exit( 1 )
 
   if log:
-    fork( log )
+    fork( log, pidfile )
 
   if debug:
     myFiber = DebugFiber

--- a/fiber.py
+++ b/fiber.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
 import sys, os, select, time, socket, traceback
 
 

--- a/fiber.py
+++ b/fiber.py
@@ -60,7 +60,7 @@ class Fiber:
     except StopIteration:
       del self.__generator
       pass
-    except AssertionError, msg:
+    except AssertionError as msg:
       print('Error:', msg)
     except:
       traceback.print_exc()
@@ -145,13 +145,13 @@ def fork( output ):
     log = open( output, 'w' )
     nul = open( '/dev/null', 'r' )
     pid = os.fork()
-  except IOError, e:
+  except IOError as e:
     print('error: failed to open', e.filename)
     sys.exit( 1 )
-  except OSError, e:
+  except OSError as e:
     print('error: failed to fork process:', e.strerror)
     sys.exit( 1 )
-  except Exception, e:
+  except Exception as e:
     print('error:', e)
     sys.exit( 1 )
 
@@ -165,7 +165,7 @@ def fork( output ):
     # -rw-r--r-- / 0644 / u=rw,go=r
     os.umask( 0022 )
     pid = os.fork()
-  except Exception, e: 
+  except Exception as e: 
     print('error:', e)
     sys.exit( 1 )
 
@@ -186,7 +186,7 @@ def spawn( generator, port, debug, log ):
     listener.setsockopt( socket.SOL_SOCKET, socket.SO_REUSEADDR, listener.getsockopt( socket.SOL_SOCKET, socket.SO_REUSEADDR ) | 1 )
     listener.bind( ( '', port ) )
     listener.listen( 5 )
-  except Exception, e:
+  except Exception as e:
     print('error: failed to create socket:', e)
     sys.exit( 1 )
 

--- a/fiber.py
+++ b/fiber.py
@@ -52,7 +52,7 @@ class Fiber:
       if throw:
         assert hasattr( self.__generator, 'throw' ), throw
         self.__generator.throw( AssertionError, throw )
-      state = self.__generator.next()
+      state = next(self.__generator)
       assert isinstance( state, (SEND, RECV, WAIT) ), 'invalid waiting state %r' % state
       self.state = state
     except KeyboardInterrupt:

--- a/fiber.py
+++ b/fiber.py
@@ -181,13 +181,15 @@ def fork( output, pidfile ):
   os.dup2( nul.fileno(), sys.stdin.fileno()  )
 
 
-def spawn( generator, port, debug=False, log=None, pidfile=None ):
+def spawn( generator, bindaddr, port, debug=False, log=None, pidfile=None ):
 
   try:
-    listener = socket.socket( socket.AF_INET, socket.SOCK_STREAM )
+    addrs = socket.getaddrinfo(bindaddr, port, type=socket.SOCK_STREAM)
+    family, socktype, proto, canonname, sockaddr = addrs[0]
+    listener = socket.socket(family, socktype, proto)
     listener.setblocking( 0 )
     listener.setsockopt( socket.SOL_SOCKET, socket.SO_REUSEADDR, listener.getsockopt( socket.SOL_SOCKET, socket.SO_REUSEADDR ) | 1 )
-    listener.bind( ( '', port ) )
+    listener.bind(sockaddr[:2])
     listener.listen( 5 )
   except Exception as e:
     print('error: failed to create socket:', e)

--- a/fiber.py
+++ b/fiber.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
+import six
 import sys, os, select, time, socket, traceback
 
 

--- a/fiber.py
+++ b/fiber.py
@@ -140,7 +140,7 @@ class DebugFiber( Fiber ):
 def fork( output, pidfile ):
 
   try:
-    log = open( output, 'w' )
+    log = open( output, 'a' )
     nul = open( '/dev/null', 'r' )
     pid = os.fork()
     if pidfile:

--- a/fiber.py
+++ b/fiber.py
@@ -215,7 +215,7 @@ def spawn( generator, port, debug, log ):
         i -= 1
         state = fibers[ i ].state
 
-        if state and now > state.expire:
+        if state and (state.expire is None  or  now > state.expire):
           if isinstance( state, WAIT ):
             fibers[ i ].step()
           else:
@@ -233,7 +233,7 @@ def spawn( generator, port, debug, log ):
         elif state.expire is None:
           continue
 
-        if state.expire < expire or expire is None:
+        if state.expire is None or expire is None or state.expire < expire:
           expire = state.expire
 
       if expire is None:

--- a/fiber.py
+++ b/fiber.py
@@ -163,7 +163,7 @@ def fork( output ):
     os.chdir( os.sep )
     os.setsid() 
     # -rw-r--r-- / 0644 / u=rw,go=r
-    os.umask( 0022 )
+    os.umask( 0o022 )
     pid = os.fork()
   except Exception as e: 
     print('error:', e)

--- a/fiber.py
+++ b/fiber.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-import six
 import sys, os, select, time, socket, traceback
 
 

--- a/fiber.py
+++ b/fiber.py
@@ -61,7 +61,7 @@ class Fiber:
       del self.__generator
       pass
     except AssertionError, msg:
-      print 'Error:', msg
+      print('Error:', msg)
     except:
       traceback.print_exc()
 
@@ -125,7 +125,7 @@ class DebugFiber( Fiber ):
       sys.stdout = sys.stderr = self
       Fiber.step( self, throw )
       if self.state:
-        print 'Waiting at', self
+        print('Waiting at', self)
     finally:
       sys.stdout = stdout
       sys.stderr = stderr
@@ -146,13 +146,13 @@ def fork( output ):
     nul = open( '/dev/null', 'r' )
     pid = os.fork()
   except IOError, e:
-    print 'error: failed to open', e.filename
+    print('error: failed to open', e.filename)
     sys.exit( 1 )
   except OSError, e:
-    print 'error: failed to fork process:', e.strerror
+    print('error: failed to fork process:', e.strerror)
     sys.exit( 1 )
   except Exception, e:
-    print 'error:', e
+    print('error:', e)
     sys.exit( 1 )
 
   if pid:
@@ -166,11 +166,11 @@ def fork( output ):
     os.umask( 0022 )
     pid = os.fork()
   except Exception, e: 
-    print 'error:', e
+    print('error:', e)
     sys.exit( 1 )
 
   if pid:
-    print pid
+    print(pid)
     sys.exit( 0 )
 
   os.dup2( log.fileno(), sys.stdout.fileno() )
@@ -187,7 +187,7 @@ def spawn( generator, port, debug, log ):
     listener.bind( ( '', port ) )
     listener.listen( 5 )
   except Exception, e:
-    print 'error: failed to create socket:', e
+    print('error: failed to create socket:', e)
     sys.exit( 1 )
 
   if log:
@@ -198,7 +198,7 @@ def spawn( generator, port, debug, log ):
   else:
     myFiber = GatherFiber
 
-  print '[ INIT ]', generator.__name__, 'started at %s:%i' % ( socket.gethostname(), port )
+  print('[ INIT ]', generator.__name__, 'started at %s:%i' % ( socket.gethostname(), port ))
   try:
 
     fibers = []
@@ -237,10 +237,10 @@ def spawn( generator, port, debug, log ):
           expire = state.expire
 
       if expire is None:
-        print '[ IDLE ]', time.ctime()
+        print('[ IDLE ]', time.ctime())
         sys.stdout.flush()
         canrecv, cansend, dummy = select.select( tryrecv, trysend, [] )
-        print '[ BUSY ]', time.ctime()
+        print('[ BUSY ]', time.ctime())
         sys.stdout.flush()
       else:
         canrecv, cansend, dummy = select.select( tryrecv, trysend, [], max( expire - now, 0 ) )
@@ -254,9 +254,9 @@ def spawn( generator, port, debug, log ):
         trysend[ fileno ].step()
 
   except KeyboardInterrupt:
-    print '[ DONE ]', generator.__name__, 'terminated'
+    print('[ DONE ]', generator.__name__, 'terminated')
     sys.exit( 0 )
   except:
-    print '[ DONE ]', generator.__name__, 'crashed'
+    print('[ DONE ]', generator.__name__, 'crashed')
     traceback.print_exc( file=sys.stdout )
     sys.exit( 1 )

--- a/http-replicator
+++ b/http-replicator
@@ -10,7 +10,7 @@ DOWNLOADS = weakref.WeakValueDictionary()
 
 def Replicator( client, address ):
 
-  print 'Accepted request from %s:%i' % address
+  print('Accepted request from %s:%i' % address)
 
   request = Request.HttpRequest( client )
   for state in request:
@@ -21,14 +21,14 @@ def Replicator( client, address ):
       protocol = DOWNLOADS[ request ]
       if protocol.Response:
         if issubclass( protocol.Response, Response.DataResponse ):
-          print 'Joined running download'
+          print('Joined running download')
           break
         del DOWNLOADS[ request ]
       else:
         yield fiber.WAIT()
     else:
       if Params.VERBOSE:
-        print 'Switching to', request.Protocol.__name__
+        print('Switching to', request.Protocol.__name__)
       protocol = DOWNLOADS[ request ] = request.Protocol( request )
       server = protocol.socket()
       while not protocol.Response:
@@ -39,12 +39,12 @@ def Replicator( client, address ):
           yield fiber.RECV( server, Params.TIMEOUT )
           protocol.recv( server )
     if Params.VERBOSE:
-      print 'Switching to', protocol.Response.__name__
+      print('Switching to', protocol.Response.__name__)
     response = protocol.Response( protocol, request )
     server = protocol.socket()
   except Exception:
     if Params.VERBOSE:
-      print 'Switching to ExceptionResponse'
+      print('Switching to ExceptionResponse')
     response = Response.ExceptionResponse( request )
 
   while not response.Done:
@@ -57,7 +57,7 @@ def Replicator( client, address ):
       yield fiber.RECV( server, Params.TIMEOUT )
       response.recv( server )
 
-  print 'Transaction successfully completed'
+  print('Transaction successfully completed')
 
 
 fiber.spawn( Replicator, Params.PORT, Params.DEBUG, Params.LOG )

--- a/http-replicator
+++ b/http-replicator
@@ -6,7 +6,7 @@ DOWNLOADS = weakref.WeakValueDictionary()
 
 def Replicator( client, address ):
 
-  print('Accepted request from %s:%i' % address)
+  print('Accepted request from %s:%i' % address[:2])
 
   request = Request.HttpRequest( client )
   for state in request:
@@ -56,4 +56,4 @@ def Replicator( client, address ):
   print('Transaction successfully completed')
 
 
-fiber.spawn( Replicator, Params.PORT, Params.DEBUG, Params.LOG, Params.PIDFILE )
+fiber.spawn( Replicator, Params.BIND, Params.PORT, Params.DEBUG, Params.LOG, Params.PIDFILE )

--- a/http-replicator
+++ b/http-replicator
@@ -13,7 +13,7 @@ def Replicator( client, address ):
     yield state
 
   try:
-    while request in DOWNLOADS:
+    for request in DOWNLOADS:
       protocol = DOWNLOADS[ request ]
       if protocol.Response:
         if issubclass( protocol.Response, Response.DataResponse ):

--- a/http-replicator
+++ b/http-replicator
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 from __future__ import absolute_import, division, print_function, unicode_literals
+import six
 import Params, Request, Response, fiber, weakref
 
 

--- a/http-replicator
+++ b/http-replicator
@@ -56,4 +56,4 @@ def Replicator( client, address ):
   print('Transaction successfully completed')
 
 
-fiber.spawn( Replicator, Params.PORT, Params.DEBUG, Params.LOG )
+fiber.spawn( Replicator, Params.PORT, Params.DEBUG, Params.LOG, Params.PIDFILE )

--- a/http-replicator
+++ b/http-replicator
@@ -1,12 +1,8 @@
 #! /usr/bin/env python
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-import six
 import Params, Request, Response, fiber, weakref
 
-
 DOWNLOADS = weakref.WeakValueDictionary()
-
 
 def Replicator( client, address ):
 

--- a/http-replicator
+++ b/http-replicator
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-
+from __future__ import absolute_import, division, print_function, unicode_literals
 import Params, Request, Response, fiber, weakref
 
 

--- a/unit-test
+++ b/unit-test
@@ -234,7 +234,7 @@ for NUM; do
     13)
       begintest "$NUM" "RATE CONTROL" '' --limit 10
       http_proxy_download "$URL_HTTP" out
-      saymsg "download speed: should be approximately 10240" "USER" "to verify"
+      saymsg "download speed: should be approximately 10 KiB/s" "USER" "to verify"
       check_equal "cached and served file are equal" cache/"$BASE_HTTP" out
       endtest
       ;;

--- a/unit-test
+++ b/unit-test
@@ -1,298 +1,266 @@
 #! /bin/bash
 
+#local resources used by this script
+BIND=localhost
 PORT=8090
-NUM="$1"
-PREFIX="/tmp/unittest$NUM"
-URL_HTTP="www.w3.org:80/Protocols/HTTP/1.1/rfc2616bis/draft-lafon-rfc2616bis-03.txt"
-URL_CHUNKED="jigsaw.w3.org:80/HTTP/ChunkedScript"
-URL_FTP="ftp.debian.org:21/debian/doc/FAQ/debian-faq.en.pdf.gz"
-PID="/tmp/unittest.$PORT"
+BASEDIR=/tmp/replicator-unittest
 
-if test -z "$1"; then
-  while $0 $((++i)); do true; done
-  exit 0
-fi
+#remote resources used for testing
+URL_HTTP=http://www.w3.org:80/Protocols/HTTP/1.1/rfc2616bis/draft-lafon-rfc2616bis-03.txt
+URL_CHUNKED=http://jigsaw.w3.org:80/HTTP/ChunkedScript
+URL_FTP=ftp://ftp.ibiblio.org:21/pub/linux/docs/faqs/Linux-FAQ/Linux-FAQ.pdf
+
+#derived from above
+BASE_HTTP=${URL_HTTP#*://}
+BASE_CHUNKED=${URL_CHUNKED#*://}
+BASE_FTP=${URL_FTP#*://}
+
+mkdir -p "$BASEDIR"
+case "$#" in
+  0) set -- $(seq 1 16) ;;
+esac
+
 
 ########## AUXILIARY FUNCTIONS ################################################
 
-function startserver
-{
-  test -e $PID && kill -int `cat $PID`
-  rm -rf $PREFIX.*
-  mkdir $PREFIX.cache
-  if ! ./http-replicator -p $PORT -r $PREFIX.cache -v -v $@ --daemon $PREFIX.log > $PID; then
-    cat $PID
-    rm $PID
-    exit 1
-  fi
+function startserver {
+  SERVER_PID=$(
+    ulimit -f "${1:-unlimited}"
+    shift
+    ./http-replicator \
+      -b "$BIND" -p "$PORT" \
+      -r "$PREFIX".cache -v -v \
+      --daemon "$PREFIX".log \
+      "$@"
+  )
+  sleep 1  # race: try to allow server to start before we access it...
 }
 
-if which wget > /dev/null; then
-  function download
-  {
-    if test -e $PREFIX.$2; then
-      WGETARGS="-c"
-    fi
-    wget -O $PREFIX.$2 $1 $WGETARGS 1>&2
-  }
-elif which curl > /dev/null; then
-  function download
-  {
-    if test -e $PREFIX.$2; then
-      CURLARGS="-C -"
-    fi
-    curl -o $PREFIX.$2 $CURLARGS $1 1>&2
-  }
-else
-  echo "error: no download tool available"
-  exit 1
-fi
-
-function abort
-{
-  sleep $1
-  if kill %%; then
-    echo
-    sleep 1
-  else
-    echo "error: download finished unexpectedly soon"
-    exit 1
-  fi
+function stopserver {
+  kill "$SERVER_PID"
+  wait
 }
 
-function touchfile
-{
-  FILENAME=$PREFIX.$1
-  shift
-  mkdir -p `dirname $FILENAME`
-  touch $@ $FILENAME
-}
-
-function summary
-{
-  sleep .5
+function begintest {
+  PREFIX=$BASEDIR/$1
   echo "============================================================================="
-  echo " UNIT-TEST $NUM: $1"
+  echo " UNIT-TEST $1: $2"
   echo " ---------------------------------------------------------------------------"
+  rm -rf "$PREFIX".*
+  mkdir -p "$PREFIX".cache
+  shift 2
+  startserver "$@"
 }
 
-function check
-{
-  printf " * %-67s %5s %s\n" "$1" "$2" "$3"
-}
-
-function check_exists
-{
-  if test -e $PREFIX.$2; then
-    check "$1" OK
-  else
-    check "$1" ERROR
-  fi
-}
-
-if which md5 > /dev/null; then
-  function checksum
-  {
-    md5 -q $1
-  }
-elif which md5sum cut > /dev/null; then
-  function checksum
-  {
-    md5sum $1 | cut -d ' ' -f 1
-  }
-else
-  echo "error: no checksum tool available"
-  exit 1
-fi
-
-function check_equal
-{
-  if test ! -e $PREFIX.$2; then
-    check "$1" ERROR "1st file missing" 
-  elif test ! -e $PREFIX.$3; then
-    check "$1" ERROR "2nd file missing" 
-  elif test `checksum $PREFIX.$2` != `checksum $PREFIX.$3`; then
-    check "$1" ERROR "files not equal"
-  else
-    check "$1" OK
-  fi
-}
-
-function check_log
-{
-  if grep -q "$2" $PREFIX.log; then
-    check "$1" OK
-  else
-    check "$1" ERROR
-  fi
-}
-
-function stopserver
-{
+function endtest {
+  stopserver
   echo "============================================================================="
-  echo
-  if test -e $PID; then
-    kill -int `cat $PID`
-    rm $PID
+  echo ""
+}
+
+
+function download {
+  local url=$1 suffix=$2
+  shift 2
+  wget -o "$PREFIX".wget -O "$PREFIX.$suffix" -c -t 1 "$@" "$url"
+  #or something like: curl -o "$PREFIX.$suffix" -C -  -f "$@" "$url" 2>>"$PREFIX".curl
+}
+
+function http_proxy_download {
+  http_proxy="localhost:$PORT" download "$@"
+}
+
+function ftp_proxy_download {
+  ftp_proxy="localhost:$PORT" download "$@"
+}
+
+function touchfile {
+  local filename=$PREFIX.$1
+  mkdir -p "$(dirname "$filename")"
+  shift
+  touch "$@" "$filename"
+}
+
+
+function saymsg {
+  local msg=$1 status=$2
+  shift 2
+  printf " * %-67s %5s %s\n" "$msg" "$status" "$*"
+}
+
+function check_exists {
+  if test -e "$PREFIX.cache/$2"; then
+    saymsg "$1" OK
+  else
+    saymsg "$1" ERROR
+  fi
+}
+
+function check_equal {
+  local msg=$1 f1=$PREFIX.$2 f2=$PREFIX.$3
+  if test ! -e "$f1"; then
+    saymsg "$msg" ERROR "1st file missing"
+  elif test ! -e "$f2"; then
+    saymsg "$msg" ERROR "2nd file missing"
+  elif ! cmp -s "$f1" "$f2"; then
+    saymsg "$msg" ERROR "files not equal"
+  else
+    saymsg "$msg" OK
+  fi
+}
+
+function check_log {
+  if grep -q "$2" "$PREFIX".log; then
+    saymsg "$1" OK
+  else
+    saymsg "$1" ERROR
   fi
 }
 
 ########## UNIT TESTS #########################################################
 
-set -m
-case $1 in
-  1)
-    startserver
-    download http://$URL_HTTP out1
-    http_proxy=localhost:$PORT download http://$URL_HTTP out2
-    summary "DOWNLOADING NEW FILE"
-    check_exists "file cached and finalized" cache/$URL_HTTP
-    check_equal "separate download and served file are equal" out1 out2
-    check_equal "cached and served file are equal" cache/$URL_HTTP out2
-    stopserver
-    ;;
-  2)
-    startserver
-    http_proxy=localhost:$PORT download http://$URL_HTTP out & abort 1
-    summary "LEAVING PARTIAL FILE IN CACHE"
-    check_exists "file cached, not finalized" cache/$URL_HTTP.incomplete
-    stopserver
-    ;;
-  3)
-    startserver
-    http_proxy=localhost:$PORT download http://$URL_HTTP out1
-    http_proxy=localhost:$PORT download http://$URL_HTTP out2
-    summary "SERVING FILE FROM CACHE"
-    check_exists "first file cached and finalized" cache/$URL_HTTP
-    check_log "second file served from cache" "Reading complete file from cache"
-    check_equal "cached and first served file are equal" cache/$URL_HTTP out1
-    check_equal "cached and second served file are equal" cache/$URL_HTTP out2
-    stopserver
-    ;;
-  4)
-    startserver
-    download http://$URL_HTTP out & abort 1
-    http_proxy=localhost:$PORT download http://$URL_HTTP out
-    summary "RESUMING PARTIAL FILE BY CLIENT"
-    check_log "received complete file" "Server responds HTTP/1.1 200 OK"
-    check_log "served partial file" "Replicator responds HTTP/1.1 206 Partial Content"
-    check_equal "cached and served file are equal" cache/$URL_HTTP out
-    stopserver
-    ;;
-  5)
-    startserver
-    touchfile cache/$URL_HTTP -m -t 190112140000 
-    http_proxy=localhost:$PORT download http://$URL_HTTP out
-    summary "REDOWNLOADING CHANGED FILE"
-    check_log "detected complete file in cache" "Checking complete file in cache"
-    check_log "downloading new file" "Preparing new file in cache"
-    check_equal "cached and served file are equal" cache/$URL_HTTP out
-    stopserver
-    ;;
-  6)
-    startserver
-    http_proxy=localhost:$PORT download http://$URL_HTTP out1 & abort 1
-    http_proxy=localhost:$PORT download http://$URL_HTTP out2
-    summary "RESUMING PARTIAL UNCHANGED FILE IN CACHE"
-    check_log "replicator asks for missing part" "Requesting resume of partial file in cache"
-    check_log "received partial file" "Server responds HTTP/1.1 206 Partial Content"
-    check_equal "cached and served file are equal" cache/$URL_HTTP out2
-    stopserver
-    ;;
-  7)
-    startserver
-    touchfile cache/$URL_HTTP.incomplete
-    http_proxy=localhost:$PORT download http://$URL_HTTP out
-    summary "RESUMING PARTIAL CHANGED FILE IN CACHE"
-    check_log "replicator asks for missing part" "Requesting resume of partial file in cache"
-    check_log "received complete file" "Server responds HTTP/1.1 200 OK"
-    check_equal "cached and served file are equal" cache/$URL_HTTP out
-    stopserver
-    ;;
-  8)
-    startserver
-    http_proxy=localhost:$PORT download http://$URL_HTTP out1 > /dev/null & sleep 1
-    http_proxy=localhost:$PORT download http://$URL_HTTP out2
-    summary "JOINING DOWNLOADS"
-    check_log "downloads are joined" "Joined running download"
-    check_equal "cached and first served file are equal" cache/$URL_HTTP out1
-    check_equal "cached and second served file are equal" cache/$URL_HTTP out2
-    stopserver
-    ;;
-  9)
-    startserver
-    download http://$URL_CHUNKED out1
-    http_proxy=localhost:$PORT download http://$URL_CHUNKED out2
-    summary "DOWNLOADING NEW FILE, CHUNKED TRANSFER"
-    check_equal "separate download and served file are equal" out1 out2
-    check_log "server sends chunked data" "Transfer-Encoding: chunked"
-    check_log "processing chunked data" "Switching to ChunkedDataResponse"
-    check_equal "cached and served file are equal" cache/$URL_CHUNKED out2
-    stopserver
-    ;;
-  10)
-    startserver
-    download ftp://$URL_FTP out1
-    ftp_proxy=localhost:$PORT download ftp://$URL_FTP out2
-    summary "DOWNLOADING NEW FILE, FTP TRANSFER"
-    check_equal "separate download and served file are equal" out1 out2
-    check_equal "cached and served file are equal" cache/$URL_FTP out2
-    stopserver
-    ;;
-  11)
-    startserver
-    ftp_proxy=localhost:$PORT download ftp://$URL_FTP out1
-    ftp_proxy=localhost:$PORT download ftp://$URL_FTP out2
-    summary "SERVING FILE FROM CACHE, FTP TRANSFER"
-    check_exists "first file cached and finalized" cache/$URL_FTP
-    check_log "second file served from cache" "Reading complete file from cache"
-    check_equal "cached and first served file are equal" cache/$URL_FTP out1
-    check_equal "cached and second served file are equal" cache/$URL_FTP out2
-    stopserver
-    ;;
-  12)
-    startserver
-    ftp_proxy=localhost:$PORT download ftp://$URL_FTP out1 & abort 1
-    ftp_proxy=localhost:$PORT download ftp://$URL_FTP out2
-    summary "RESUMING PARTIAL UNCHANGED FILE IN CACHE, FTP TRANSFER"
-    check_log "replicator resumes file" "Resuming partial file in cache"
-    check_equal "cached and served file are equal" cache/$URL_FTP out2
-    stopserver
-    ;;
-  13)
-    startserver --limit 10
-    http_proxy=localhost:$PORT download http://$URL_HTTP out
-    summary "RATE CONTROL"
-    check "download speed; should be approximately 10240" CHECK
-    check_equal "cached and served file are equal" cache/$URL_HTTP out
-    stopserver
-    ;;
-  14)
-    startserver --static
-    http_proxy=localhost:$PORT download http://$URL_HTTP out1
-    http_proxy=localhost:$PORT download http://$URL_HTTP out2
-    summary "STATIC MODE"
-    check_log "serving directly from cache without consulting server" "Static mode; serving file directly from cache"
-    check_equal "cached and served file are equal" cache/$URL_HTTP out2
-    stopserver
-    ;;
-  15)
-    startserver --offline
-    http_proxy=localhost:$PORT download http://$URL_HTTP out
-    summary "OFF-LINE MODE"
-    check_log "refusing to connect to server" "AssertionError: operating in off-line mode"
-    stopserver
-    ;;
-  16)
-    startserver --flat
-    http_proxy=localhost:$PORT download http://$URL_HTTP out
-    summary "DOWNLOADING NEW FILE, FLAT MODE"
-    check_log "serving complete file" "Replicator responds HTTP/1.1 200 OK"
-    check_exists "file cached and finalized" cache/`basename $URL_HTTP`
-    stopserver
-    ;;
-  *)
-    exit 1
-    ;;
-esac
-exit 0
+for NUM; do
+  case $NUM in
+    1)
+      begintest "$NUM" "DOWNLOADING NEW FILE"
+      download "$URL_HTTP" reference
+      http_proxy_download "$URL_HTTP" out
+      check_exists "file cached and finalized" "$BASE_HTTP"
+      check_equal "reference and served file are equal" reference out
+      check_equal "served and cached file are equal" cache/"$BASE_HTTP" out
+      endtest
+      ;;
+    2)
+      begintest "$NUM" "LEAVING PARTIAL FILE IN CACHE" 192
+      http_proxy_download "$URL_HTTP" out
+      check_exists "file cached, not finalized" "$BASE_HTTP.incomplete"
+      endtest
+      ;;
+    3)
+      begintest "$NUM" "SERVING FILE FROM CACHE"
+      http_proxy_download "$URL_HTTP" out1
+      http_proxy_download "$URL_HTTP" out2
+      check_exists "first file cached and finalized" "$BASE_HTTP"
+      check_log "second file served from cache" "Reading complete file from cache"
+      check_equal "cached and first served file are equal" cache/"$BASE_HTTP" out1
+      check_equal "cached and second served file are equal" cache/"$BASE_HTTP" out2
+      endtest
+      ;;
+    4)
+      begintest "$NUM" "RESUMING PARTIAL FILE BY CLIENT"
+      download "$URL_HTTP" reference
+      head -c 183K "$PREFIX".reference > "$PREFIX".out
+      http_proxy_download "$URL_HTTP" out
+      check_log "received complete file" "Server responds HTTP/1.1 200 OK"
+      check_log "served partial file" "Replicator responds HTTP/1.1 206 Partial Content"
+      check_equal "reference and served file are equal" reference out
+      check_equal "cached and served file are equal" cache/"$BASE_HTTP" out
+      endtest
+      ;;
+    5)
+      begintest "$NUM" "REDOWNLOADING CHANGED FILE"
+      touchfile cache/"$BASE_HTTP" -m -t 190112140000
+      http_proxy_download "$URL_HTTP" out
+      check_log "detected complete file in cache" "Checking complete file in cache"
+      check_log "downloading new file" "Preparing new file in cache"
+      check_equal "cached and served file are equal" cache/"$BASE_HTTP" out
+      endtest
+      ;;
+    6)
+      begintest "$NUM" "RESUMING PARTIAL UNCHANGED FILE IN CACHE" 334
+      http_proxy_download "$URL_HTTP" out1
+      stopserver; sleep 1; startserver
+      http_proxy_download "$URL_HTTP" out2
+      check_log "replicator asks for missing part" "Requesting resume of partial file in cache"
+      check_log "received partial file" "Server responds HTTP/1.1 206 Partial Content"
+      check_equal "cached and served file are equal" cache/"$BASE_HTTP" out2
+      endtest
+      ;;
+    7)
+      begintest "$NUM" "RESUMING PARTIAL CHANGED FILE IN CACHE"
+      touchfile cache/"$BASE_HTTP.incomplete"
+      http_proxy_download "$URL_HTTP" out
+      check_log "replicator asks for missing part" "Requesting resume of partial file in cache"
+      check_log "received complete file" "Server responds HTTP/1.1 200 OK"
+      check_equal "cached and served file are equal" cache/"$BASE_HTTP" out
+      endtest
+      ;;
+    8)
+      begintest "$NUM" "JOINING DOWNLOADS"
+      http_proxy_download "$URL_HTTP" out1 > /dev/null & sleep 1
+      http_proxy_download "$URL_HTTP" out2
+      check_log "downloads are joined" "Joined running download"
+      check_equal "cached and first served file are equal" cache/"$BASE_HTTP" out1
+      check_equal "cached and second served file are equal" cache/"$BASE_HTTP" out2
+      endtest
+      ;;
+    9)
+      begintest "$NUM" "DOWNLOADING NEW FILE, CHUNKED TRANSFER"
+      download "$URL_CHUNKED" reference
+      http_proxy_download "$URL_CHUNKED" out
+      check_equal "separate download and served file are equal" reference out
+      check_log "server sends chunked data" "transfer-encoding: chunked"
+      check_log "processing chunked data" "Switching to ChunkedDataResponse"
+      check_equal "cached and served file are equal" cache/"$BASE_CHUNKED" out
+      endtest
+      ;;
+    10)
+      begintest "$NUM" "DOWNLOADING NEW FILE, FTP TRANSFER"
+      download "$URL_FTP" reference
+      ftp_proxy_download "$URL_FTP" out
+      check_equal "separate download and served file are equal" reference out
+      check_equal "cached and served file are equal" cache/"$BASE_FTP" out
+      endtest
+      ;;
+    11)
+      begintest "$NUM" "SERVING FILE FROM CACHE, FTP TRANSFER"
+      ftp_proxy_download "$URL_FTP" out1
+      ftp_proxy_download "$URL_FTP" out2
+      check_exists "first file cached and finalized" "$BASE_FTP"
+      check_log "second file served from cache" "Reading complete file from cache"
+      check_equal "cached and first served file are equal" cache/"$BASE_FTP" out1
+      check_equal "cached and second served file are equal" cache/"$BASE_FTP" out2
+      endtest
+      ;;
+    12)
+      begintest "$NUM" "RESUMING PARTIAL UNCHANGED FILE IN CACHE, FTP TRANSFER" 377
+      ftp_proxy_download "$URL_FTP" out1
+      stopserver; sleep 1; startserver
+      ftp_proxy_download "$URL_FTP" out2
+      check_log "replicator resumes file" "Resuming partial file in cache"
+      check_equal "cached and served file are equal" cache/"$BASE_FTP" out2
+      endtest
+      ;;
+    13)
+      begintest "$NUM" "RATE CONTROL" '' --limit 10
+      http_proxy_download "$URL_HTTP" out
+      saymsg "download speed: should be approximately 10240" "USER" "to verify"
+      check_equal "cached and served file are equal" cache/"$BASE_HTTP" out
+      endtest
+      ;;
+    14)
+      begintest "$NUM" "STATIC MODE" '' --static
+      http_proxy_download "$URL_HTTP" out1
+      http_proxy_download "$URL_HTTP" out2
+      check_log "serving directly from cache without consulting server" "Static mode; serving file directly from cache"
+      check_equal "cached and served file are equal" cache/"$BASE_HTTP" out2
+      endtest
+      ;;
+    15)
+      begintest "$NUM" "OFF-LINE MODE" '' --offline
+      http_proxy_download "$URL_HTTP" out
+      check_log "refusing to connect to server" "AssertionError: operating in off-line mode"
+      endtest
+      ;;
+    16)
+      begintest "$NUM" "DOWNLOADING NEW FILE, FLAT MODE" '' --flat
+      http_proxy_download "$URL_HTTP" out
+      check_log "serving complete file" "Replicator responds HTTP/1.1 200 OK"
+      check_exists "file cached and finalized" "$(basename "$BASE_HTTP")"
+      endtest
+      ;;
+    *)
+      echo "Test $NUM is not defined"
+      ;;
+  esac
+done

--- a/unit-test
+++ b/unit-test
@@ -67,11 +67,11 @@ function download {
 }
 
 function http_proxy_download {
-  http_proxy="localhost:$PORT" download "$@"
+  http_proxy="$BIND:$PORT" download "$@"
 }
 
 function ftp_proxy_download {
-  ftp_proxy="localhost:$PORT" download "$@"
+  ftp_proxy="$BIND:$PORT" download "$@"
 }
 
 function touchfile {


### PR DESCRIPTION
I've migrated your replicator caching server to run under Python 3 (instead of Python 2; I did not bother to maintain backward compatibility).  I also added a small amount of extra functionality to be compatible with the Gentoo distribution.

Given that your code has not been updated since 2008, I'm not sure how much you care, but I figured it'd at least be polite to let you know...